### PR TITLE
fix: Can't build twice because of the Node.js' require cache.

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -13,28 +13,32 @@ var webpackConfig = require('./webpack.prod.conf')
 var spinner = ora('building for production...')
 spinner.start()
 
-rm(path.join(config.build.assetsRoot, config.build.assetsSubDirectory), err => {
-  if (err) throw err
-  webpack(webpackConfig, function (err, stats) {
-    spinner.stop()
-    if (err) throw err
-    process.stdout.write(stats.toString({
-      colors: true,
-      modules: false,
-      children: false,
-      chunks: false,
-      chunkModules: false
-    }) + '\n\n')
+module.exports = () => new Promise((resolve, reject) => {
+  rm(path.join(config.build.assetsRoot, config.build.assetsSubDirectory), err => {
+    if (err) reject(err)
+    webpack(webpackConfig, function (err, stats) {
+      spinner.stop()
+      if (err) reject(err)
+      process.stdout.write(stats.toString({
+        colors: true,
+        modules: false,
+        children: false,
+        chunks: false,
+        chunkModules: false
+      }) + '\n\n')
 
-    if (stats.hasErrors()) {
-      console.log(chalk.red('  Build failed with errors.\n'))
-      process.exit(1)
-    }
+      if (stats.hasErrors()) {
+        console.log(chalk.red('  Build failed with errors.\n'))
+        process.exit(1)
+      }
 
-    console.log(chalk.cyan('  Build complete.\n'))
-    console.log(chalk.yellow(
-      '  Tip: built files are meant to be served over an HTTP server.\n' +
-      '  Opening index.html over file:// won\'t work.\n'
-    ))
+      console.log(chalk.cyan('  Build complete.\n'))
+      console.log(chalk.yellow(
+        '  Tip: built files are meant to be served over an HTTP server.\n' +
+        '  Opening index.html over file:// won\'t work.\n'
+      ))
+
+      resolve()
+    })
   })
 })

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const injectArgvOptions = require('./config/argv').injectArgvOptions
 
 function build (argvOptions) {
   injectArgvOptions(argvOptions)
-  return require('./build/build.js')
+  return require('./build/build.js')()
 }
 
 function devServer (argvOptions) {


### PR DESCRIPTION
`build` 方法原本使用 `require` 触发执行的方法实现，由于 Node.js 在 require 时是有缓存的，除非手动删除缓存，否则无法执行第二次，所以改为函数调用的方式，支持多次调用。

同时增加了一个 `Promise` 的返回，因为这个操作是异步的。