### PR TITLE
【功能测试中】Mpvue子包剔留可配置化

### DIFF
--- a/config/argv.js
+++ b/config/argv.js
@@ -101,6 +101,7 @@ function mergeArgvConfig (config) {
     output: argvOutput,               // pathString, undefined
     config: argvCnf,                  // pathString, undefined
     definePlugin: argvDefinePlugin,   // object, undefined
+    removeMpvue: argvTidyMpvue,
     ...resetConfig
   } = argv
   const mpType = argvComponent ? 'component' : 'page'
@@ -149,6 +150,17 @@ function mergeArgvConfig (config) {
     }
   })
 
+  // 剔除mpvue
+  if (argvTidyMpvue) {
+    config.argvConfig.externals = [
+      function (context, request, callback) {
+        if (/^vue$/.test(request)) {
+          return callback(null, 'commonjs ' + request);
+        }
+        callback();
+      }
+    ];
+  }
   // DefinePlugin
   if (argvDefinePlugin) {
     config.argvConfig.plugins.push(new webpack.DefinePlugin(argvDefinePlugin))


### PR DESCRIPTION
**注：功能测试未完成**

背景：部分情景下，主包子包均存在Mpvue库，因此剔除子包Mpvue可减少项目代码体积。

功能：Mpvue剔留可配置化以 支持并入主包的Mpvue复用。